### PR TITLE
[WIP] Minerva txs

### DIFF
--- a/aecore_eqc/txs_eqc.erl
+++ b/aecore_eqc/txs_eqc.erl
@@ -2323,7 +2323,7 @@ setup_data_dir(Prop) ->
     %% make sure we can run in eqc/aecore_eqc
     ?SETUP(fun() ->
                    {ok, Dir} = file:get_cwd(),
-                   DataDir = application:get_env(setup, data_dir),
+                   undefined = application:get_env(setup, data_dir),
                    case lists:reverse(filename:split(Dir)) of
                        [_, "eqc" | _] ->
                            application:set_env(setup, data_dir, "../../data");
@@ -2331,6 +2331,6 @@ setup_data_dir(Prop) ->
                            application:set_env(setup, data_dir, "data")
                    end,
                    fun() ->
-                           application:set_env(setup, data_dir, DataDir)
+                           ok = application:unset_env(setup, data_dir)
                    end
            end, Prop).

--- a/aecore_eqc/txs_eqc.erl
+++ b/aecore_eqc/txs_eqc.erl
@@ -1720,7 +1720,8 @@ prop_txs(Fork) ->
                                    #{<<"1">> => 0, <<"2">> => Fork, <<"3">> => 2*Fork}),
     application:load(aesophia),  %% Since we do in_parallel, we may have a race in line 86 of aesophia_compiler
     compile_contracts(),
-    setup_data_dir(
+    ?SETUP(
+    fun setup_data_dir/0,
     eqc:dont_print_counterexample(
     in_parallel(
     ?FORALL(Cmds, commands(?MODULE),
@@ -2319,18 +2320,16 @@ fake_contract_id() ->
                   }).
 
 
-setup_data_dir(Prop) ->
+setup_data_dir() ->
     %% make sure we can run in eqc/aecore_eqc
-    ?SETUP(fun() ->
-                   {ok, Dir} = file:get_cwd(),
-                   undefined = application:get_env(setup, data_dir),
-                   case lists:reverse(filename:split(Dir)) of
-                       [_, "eqc" | _] ->
-                           application:set_env(setup, data_dir, "../../data");
-                       _ ->
-                           application:set_env(setup, data_dir, "data")
-                   end,
-                   fun() ->
-                           ok = application:unset_env(setup, data_dir)
-                   end
-           end, Prop).
+    {ok, Dir} = file:get_cwd(),
+    undefined = application:get_env(setup, data_dir),
+    case lists:reverse(filename:split(Dir)) of
+        [_, "eqc" | _] ->
+            application:set_env(setup, data_dir, "../../data");
+        _ ->
+            application:set_env(setup, data_dir, "data")
+    end,
+    fun() ->
+            ok = application:unset_env(setup, data_dir)
+    end.

--- a/aecore_eqc/txs_eqc.erl
+++ b/aecore_eqc/txs_eqc.erl
@@ -1715,12 +1715,19 @@ prop_txs() ->
     prop_txs(3).
 
 prop_txs(Fork) ->
+    prop_txs_in_forks(#{<<"1">> => 0, <<"2">> => Fork, <<"3">> => 2*Fork}).
+
+prop_txs_minerva() ->
+    Fork = 3,
+    prop_txs_in_forks(#{<<"1">> => 0, <<"2">> => Fork}).
+
+prop_txs_in_forks(HardForks = #{<<"1">> := _, <<"2">> := _}) ->
     application:load(aesophia),  %% Since we do in_parallel, we may have a race in line 86 of aesophia_compiler
     compile_contracts(),
     ?SETUP(
     fun() ->
             _ = application:load(aecore),
-            HardForksTeardown = setup_hard_forks(#{<<"1">> => 0, <<"2">> => Fork, <<"3">> => 2*Fork}),
+            HardForksTeardown = setup_hard_forks(HardForks),
             DataDirTeardown = setup_data_dir(),
             fun() ->
                     DataDirTeardown(),

--- a/aecore_eqc/txs_glue_eqc.erl
+++ b/aecore_eqc/txs_glue_eqc.erl
@@ -1432,7 +1432,7 @@ prop_txs() ->
             eqc_mocking:start_mocking(api_spec()),
             %% make sure we can run in eqc/aecore_eqc
             {ok, Dir} = file:get_cwd(),
-            DataDir = application:get_env(setup, data_dir),
+            undefined = application:get_env(setup, data_dir),
             ok = case lists:reverse(filename:split(Dir)) of
                      [_, "eqc" | _] ->
                          application:set_env(setup, data_dir, "../../data");
@@ -1441,7 +1441,7 @@ prop_txs() ->
                  end,
             fun() ->
                     eqc_mocking:stop_mocking(),
-                    ok = application:set_env(setup, data_dir, DataDir)
+                    ok = application:unset_env(setup, data_dir)
             end
     end,
     eqc:dont_print_counterexample(

--- a/aecore_eqc/txs_glue_eqc.erl
+++ b/aecore_eqc/txs_glue_eqc.erl
@@ -1430,18 +1430,10 @@ prop_txs() ->
     ?SETUP(
     fun() ->
             eqc_mocking:start_mocking(api_spec()),
-            %% make sure we can run in eqc/aecore_eqc
-            {ok, Dir} = file:get_cwd(),
-            undefined = application:get_env(setup, data_dir),
-            ok = case lists:reverse(filename:split(Dir)) of
-                     [_, "eqc" | _] ->
-                         application:set_env(setup, data_dir, "../../data");
-                     _ ->
-                         application:set_env(setup, data_dir, "data")
-                 end,
+            DataDirTeardown = setup_data_dir(),
             fun() ->
                     eqc_mocking:stop_mocking(),
-                    ok = application:unset_env(setup, data_dir)
+                    DataDirTeardown()
             end
     end,
     eqc:dont_print_counterexample(
@@ -1918,3 +1910,17 @@ fake_contract_id() ->
                    abi = nat(),
                    vm = nat()
                   }).
+
+setup_data_dir() ->
+    %% make sure we can run in eqc/aecore_eqc
+    {ok, Dir} = file:get_cwd(),
+    undefined = application:get_env(setup, data_dir),
+    case lists:reverse(filename:split(Dir)) of
+        [_, "eqc" | _] ->
+            application:set_env(setup, data_dir, "../../data");
+        _ ->
+            application:set_env(setup, data_dir, "data")
+    end,
+    fun() ->
+            ok = application:unset_env(setup, data_dir)
+    end.

--- a/aecore_eqc/txs_hardfork_eqc.erl
+++ b/aecore_eqc/txs_hardfork_eqc.erl
@@ -118,6 +118,11 @@ ns_revoke(Height, _Sender, _Name, Tx) ->
 ns_transfer(Height, _Sender, _Receiver, _Name, Tx) ->
     txs_eqc:apply_transaction(Height, aens_transfer_tx, Tx).
 
+%% --- Operation: create_contract ---
+contract_create(Height, {_, _Sender}, Name, CompilerVersion, Tx) ->
+    NewTx = txs_eqc:contract_create_tx(Name, CompilerVersion, Tx),
+    txs_eqc:apply_transaction(Height, aect_create_tx, NewTx).
+
 %% -- Property ---------------------------------------------------------------
 
 prop_txs() ->

--- a/aecore_eqc/txs_hardfork_eqc.erl
+++ b/aecore_eqc/txs_hardfork_eqc.erl
@@ -140,7 +140,7 @@ prop_txs() ->
             measure(length, commands_length(Cmds),
             measure(height, Height,
             features(call_features(H),
-            aggregate_feats([atoms, correct | all_command_names()], call_features(H),
+            aggregate_feats([atoms, correct, protocol | all_command_names()], call_features(H),
                 pretty_commands(?MODULE, Cmds, {H, S, Res},
                                 Res == ok))))))
     end)).


### PR DESCRIPTION
Includes #16

`txs_hardfork` seems an old version of `txs_eqc`, reusing `txs_eqc` but testing only up to Minerva. Shall rather a new property be added to `txs_eqc`, and `txs_hardfork` deleted?

This PR proposes such Minerva property in `txs_eqc`.