### PR TITLE
Fix test reporting false positive re dev reward

### DIFF
--- a/aecore_eqc/aec_dev_reward_eqc.erl
+++ b/aecore_eqc/aec_dev_reward_eqc.erl
@@ -50,7 +50,7 @@ prop_split() ->
                         %% {got_rewarded, equals(Beneficiaries, DevRewards)},
                         {paid_out,
                          %% some have to be paid
-                         (BeneficiaryReward1 + BeneficiaryReward2 < TotalShares) orelse
+                         ((BeneficiaryReward1 < TotalShares) and (BeneficiaryReward2 < TotalShares)) orelse
                          lists:sum(lists:map(fun({_, R}) -> R end, DevRewards)) > 0
                          },
                         {total, (AdjustedReward1


### PR DESCRIPTION
Case:
```
Shares: tot 1000 allocated 1
Beneficiaries: [{<<184,4,109,38,231,83,178,151,97,168,170,183,180,7,61,5,229,
                   252,104,182,10,134,121,71,150,24,39,3,227,81,108,144>>,
                 1}]
Rewards: {501,501}
```